### PR TITLE
Set up Cloud Agent development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+eMetrykant is a **JavaFX 21 desktop application** (Java 21 + Maven) for browsing and
+searching a Polish parish records database (baptism / confirmation / marriage / death
+books). Entry point is `pl.koder95.eme.Main`; the UI is defined in FXML under
+`src/main/resources/pl/koder95/eme/fx/`. There is no server/backend — it is a single
+GUI app.
+
+### Build / test / lint
+
+- Build (also serves as the compile check): `mvn -DskipTests package`. Artifacts land in
+  `target/` (`eMetrykant-<version>.jar` plus dependencies copied into `target/lib/`).
+- The `maven-javadoc-plugin` runs during `package` and requires `JAVA_HOME` to be set.
+  `JAVA_HOME` is exported in `~/.bashrc` (points at `/usr/lib/jvm/java-21-openjdk-amd64`);
+  if you invoke Maven from a context that does not source it, prefix the command with
+  `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64`.
+- There are **no automated tests** and **no linter** configured in this repo, so `package`
+  is the primary correctness gate.
+
+### Running the app (GUI)
+
+- A desktop is available on `DISPLAY=:1` (TigerVNC). Export `DISPLAY=:1` before launching.
+- Run with: `java -jar target/eMetrykant-<version>.jar`. The startup warning
+  `Unsupported JavaFX configuration: classes were loaded from 'unnamed module ...'` is
+  harmless (the jar runs from the classpath, not the module path).
+- The app reads `indices.xml` from the **current working directory** (`user.dir`). If the
+  file is absent it silently creates an empty one, so the window will show 0 acts. To have
+  data to browse, launch from a directory that contains a populated `indices.xml`.
+- On startup the app checks GitHub for a newer release (`RepositoryInfo`); if one is found
+  (or CLI args are passed) it shows a self-update window instead of the main window.
+
+### Data model / sample data
+
+- Sample records ship as CSV inside `data - przykładowe dane.zip` (Polish: "sample data"),
+  but the app consumes **XML** (`indices.xml`), not CSV.
+- `indices.xml` shape: `<indices><book name="..."><index .../></book>...</indices>`.
+  Book names come from `BookType` (e.g. `Księga ochrzczonych`). Each `<index>` needs an
+  `an` attribute in `sign/year` form (e.g. `1000/1998`); baptism/confirmation/death indices
+  use `name`/`surname`, marriage indices use `husband-*`/`wife-*`.
+- To turn the sample CSVs into a usable `indices.xml`, map columns
+  `surname;name;number;year` (marriage: `husband-surname;husband-name;wife-surname;wife-name;number;year`)
+  into index attributes with `an="number/year"`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for **eMetrykant**, a JavaFX 21 desktop application (Java 21 + Maven) for browsing/searching Polish parish records. Adds durable, non-obvious setup guidance to `AGENTS.md` so future agents can build and run the app.

No application code was changed — this only documents the environment.

## What was configured

- **Toolchain**: Java 21 already present; installed **Maven 3.9.9** (build tool).
- **Update script** (dependency refresh on VM startup): `mvn -q -B -DskipTests dependency:go-offline`.
- **`JAVA_HOME`**: exported in `~/.bashrc` (required by the `maven-javadoc-plugin` during `package`).
- **`AGENTS.md`**: added a `## Cursor Cloud specific instructions` section covering build/run, the GUI display, the `indices.xml` data model, and sample-data conversion.

## Verified

| Step | Command / Action | Result |
| --- | --- | --- |
| Build | `mvn -DskipTests package` | Success — jar + `target/lib/` produced |
| Version (non-GUI) | `java -jar target/eMetrykant-0.5.0-SNAPSHOT.jar -v` | Prints `0.5.0-SNAPSHOT` |
| Run (GUI) | `java -jar target/eMetrykant-<ver>.jar` on `DISPLAY=:1` | Window opens, loads 7899 acts |
| Hello-world | Search "INDRUCH" → select suggestion | Populates `INDRUCH Romualda`, Baptism `1000/1998` |

There are no automated tests or linter in this repo, so `package` is the correctness gate.

## Demo

[emetrykant_search_demo.mp4](https://cursor.com/agents/bc-92589e78-91b6-4d64-8674-2f8edbbd1c3c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Femetrykant_search_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92589e78-91b6-4d64-8674-2f8edbbd1c3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92589e78-91b6-4d64-8674-2f8edbbd1c3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

